### PR TITLE
Update lxml version from 4.4.2 to 4.5.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -29,7 +29,7 @@ gen3authz==0.4.0
 
 cdispyutils==1.0.4
 fuzzywuzzy==0.6.1
-lxml==4.4.2
+lxml==4.5.2
 simplejson==3.8.1
 lifelines==0.25.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ fuzzywuzzy==0.6.1
 gen3authz==0.2.1
 graphene==2.0.1
 jsonschema==3.2
-lxml==4.4.2
+lxml==4.5.2
 pbr==2.0.0
 psycopg2==2.8.4
 python-keystoneclient==1.8.1


### PR DESCRIPTION
`lxml` version 4.4.2 is incompatible with Python 3.8. Updating it to the latest version (4.5.2) resolves this while remaining compatible with Python 3.7.

### Bug Fixes
Closes Issue #1 

### Dependency updates
`lxml` from 4.4.2 to 4.5.2

