### PR TITLE
Remove time args for survival PEDS-168

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -183,6 +183,5 @@ def get_risktable(at_risk, time_range):
         .fillna(method="ffill")
         .rename(columns={"at_risk": "nrisk"})
         .astype({"nrisk": "int32"})
-        .query(f"time >= {min(time_range)} and time <= {max(time_range)}")
         .to_dict(orient="records")
     )


### PR DESCRIPTION
For [PEDS-168](https://pcdc.atlassian.net/browse/PEDS-168)

This PR removes the use of `startTime` and `endTime` args for fetching data and generating survival results to return.