### PR TITLE
Send data for survival plot only PEDS-252

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -96,12 +96,10 @@ def get_survival_result(data, args):
         args(dict): Request body parameters and values
 
     Returns:
-        A dict of survival result consisting of "pval", "risktable", and "survival" data
+        A dict of survival result consisting of "survival" data
         example:
 
-        {"pval": 0.1,
-         "risktable": [{ "nrisk": 30, "time": 0}],
-         "survival": [{"prob": 1.0, "time": 0.0}]}
+        {"survival": [{"prob": 1.0, "time": 0.0}]}
     """
     kmf = KaplanMeierFitter()
     variables = [x for x in [args.get("factorVariable"),


### PR DESCRIPTION
For [PEDS-252](https://pcdc.atlassian.net/browse/PEDS-252)

This PR (temporarily) removes data for p-value and number-at-risk table from response data. This might come back later depending on future discussion.

Related to https://github.com/chicagopcdc/data-portal/pull/63.