### PR TITLE
Update survival response format PEDS-387

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -115,13 +115,13 @@ def get_survival_result(data, args):
         kmf.fit(data.time, data.status)
         if args.get("result").get("risktable"):
             risktable.append({
-                "name": "All",
+                "group": [],
                 "data": get_risktable(kmf.event_table.at_risk, time_range)
             })
 
         if args.get("result").get("survival"):
             survival.append({
-                "name": "All",
+                "group": [],
                 "data": get_survival(kmf.survival_function_)
             })
     else:
@@ -130,18 +130,21 @@ def get_survival_result(data, args):
 
         for name, grouped_df in data.groupby(variables):
             name = map(str, name if isinstance(name, tuple) else (name,))
-            label = ",".join(map(lambda x: "=".join(x), zip(variables, name)))
+            group = list(map(
+                lambda x: {"variable": x[0], "value": x[1]},
+                zip(variables, name)
+            ))
 
             kmf.fit(grouped_df.time, grouped_df.status)
             if args.get("result").get("risktable"):
                 risktable.append({
-                    "name": label,
+                    "group": group,
                     "data": get_risktable(kmf.event_table.at_risk, time_range)
                 })
 
             if args.get("result").get("survival"):
                 survival.append({
-                    "name": label,
+                    "group": group,
                     "data": get_survival(kmf.survival_function_)
                 })
 


### PR DESCRIPTION
Ticket: [PEDS-387](https://pcdc.atlassian.net/browse/PEDS-387)

This PR implements updated response API format for `/survival` endpoint.  Refer to [this commit](https://github.com/chicagopcdc/Documents/commit/bdf63c63426baaea195617407a9ca48b190935e6) for update details.

The update is motivated by the bug where the stratified survival results fails to render as intended when factor/stratification variable's value includes a delimiter symbol (i.e. comma `,`). See PEDS-387 description.