### PR TITLE
Handle missing study_id data in /count endpoint PEDS-388

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/counts/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/counts/__init__.py
@@ -40,11 +40,11 @@ def get_counts_per_consortium(data, consortium=None):
     for d in data:
         if consortium is None:
             molecular_analysis_count += d.get("_molecular_analysis_count")
-            for id in d.get("study_id"):
+            for id in d.get("study_id", []):
                 study_set.add(id)
         elif consortium == d.get("consortium"):
             molecular_analysis_count += d.get("_molecular_analysis_count")
-            for id in d.get("study_id"):
+            for id in d.get("study_id", []):
                 study_set.add(id)
             subject_count += 1
 


### PR DESCRIPTION
Ticket: [PEDS-388](https://pcdc.atlassian.net/browse/PEDS-388)

This PR adds a default value of an empty list (`[]`) for getting `study_id` data to count studies. This fixes the failure to handle missing `study_id` data, which is in fact a valid case.