### PR TITLE
Fix flipped survival vars params PEDS-552

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -115,7 +115,7 @@ def fetch_fake_data(factor_var, stratification_var):
     )
 
 
-def get_survival_result(data, stratification_var, factor_var, risktable_flag, survival_flag, pval_flag):
+def get_survival_result(data, factor_var, stratification_var, risktable_flag, survival_flag, pval_flag):
     """Returns the survival results (dict) based on data and request body
 
     Args:


### PR DESCRIPTION
Ticket: [PEDS-552](https://pcdc.atlassian.net/browse/PEDS-552)

This PR fixes a silly mistake :facepalm: of the incorrect parameter order for `get_survival_result()` where `factor_var` and `stratification_var` order is flipped. The bug was introduced by https://github.com/chicagopcdc/PcdcAnalysisTools/commit/43245ac63d36f78a911f52911c049c6247789c66 which was meant to fix the missing `stratification_var` bug introduced by https://github.com/chicagopcdc/PcdcAnalysisTools/commit/955b880ff20e390044ff2b514f5c3ab12919e66b.