### PR TITLE
Fix filtering out invalid rows in survival data

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -92,7 +92,7 @@ def fetch_data(filters, efs_flag):
         pd.DataFrame.from_records(guppy_data)
         .assign(
             omitted=lambda x:
-                x[status_var].isna() | x[time_var].isna() | x[time_var] < 0,
+                ((x[status_var].isna()) | (x[time_var].isna()) | (x[time_var] < 0)),
             status=lambda x:
                 np.where(x["omitted"], None, x[status_var] == status_str),
             time=lambda x:


### PR DESCRIPTION
This PR includes a simple fix to `omitted` lambda expression not evaluating as intended, leading to the failure of filtering invalid rows out before fitting survival curves. Introduced in https://github.com/chicagopcdc/PcdcAnalysisTools/pull/44.