### PR TITLE
Fix unhandled no-fitted-count case for survival result PEDS-672

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -119,16 +119,25 @@ def get_survival_result(data, risktable_flag, survival_flag):
          "survival": [{"prob": 1.0, "time": 0.0}]}
     """
     data_kmf = data.loc[data["omitted"] == False]
-
-    kmf = KaplanMeierFitter()
-    kmf.fit(data_kmf.time, data_kmf.status)
-
     result = {
         "count": {
             "fitted": data_kmf.shape[0],
             "total": data.shape[0]
         }
     }
+
+    if result["count"]["fitted"] == 0:
+        if risktable_flag:
+            result["risktable"] = [{"nrisk": 0, "time": 0}]
+
+        if survival_flag:
+            result["survival"] = [{"prob": 0, "time": 0}]
+
+        return result
+
+    kmf = KaplanMeierFitter()
+    kmf.fit(data_kmf.time, data_kmf.status)
+
     if risktable_flag:
         time_range = range(int(np.ceil(data.time.max())) + 1)
         result["risktable"] = get_risktable(kmf.event_table, time_range)


### PR DESCRIPTION
Ticket: [PEDS-672](https://pcdc.atlassian.net/browse/PEDS-672)

This PR implements handling no-fitted-count case for survival result. Previously such case will return error since the [`fit()` method for `KaplanMeierFitter` class](https://lifelines.readthedocs.io/en/latest/fitters/univariate/KaplanMeierFitter.html#lifelines.fitters.kaplan_meier_fitter.KaplanMeierFitter.fit) expects time and status parameter values to be non-empty array/list. The fix to this issue involves avoiding fitting the KM estimate altogether and returns a sensible empty response.