### PR TITLE
Fix survival records omit condition PEDS-807

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -122,7 +122,8 @@ def fetch_data(filters, efs_flag):
         pd.DataFrame.from_records(guppy_data)
         .assign(
             omitted=lambda x:
-                ((x[status_var].isna()) | (x[time_var].isna()) | (x[time_var] < 0)),
+                ((x[status_var].isna()) | x[status_var] == 'Unknown' |
+                 (x[time_var].isna()) | (x[time_var] < 0)),
             status=lambda x:
                 np.where(x["omitted"], None, x[status_var] == status_str),
             time=lambda x:


### PR DESCRIPTION
Ticket: [PEDS-807](https://pcdc.atlassian.net/browse/PEDS-807)

This PR fixes the condition for omitting records to make sure  records with `"Unknown"` survival status is excluded from fitting survival curves to data.