### PR TITLE
Use server-side surival configuration PEDS-836

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/__init__.py
@@ -58,6 +58,12 @@ routes = [
         methods=["POST"],
     ),
     new_route(
+        "/survival/config",
+        views.survival.get_config,
+        endpoint="survival/config",
+        methods=["GET"],
+    ),
+    new_route(
         "/counts",
         views.counts.get_result,
         endpoint="counts",

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -15,6 +15,7 @@ import pandas as pd
 @auth.authorize_for_analysis("access")
 def get_result():
     args = utils.parse.parse_request_json()
+    config = capp.config.get("SURVIVAL", {"result": {}})
 
     # TODO add json payload control
     # TODO add check on payload nulls and stuff
@@ -22,8 +23,8 @@ def get_result():
     filter_sets = json.loads(json.dumps(args.get("filterSets")))
     # NOT USED FOR NOW
     # efs_flag = args.get("efsFlag")
-    risktable_flag = args.get("result").get("risktable")
-    survival_flag = args.get("result").get("survival")
+    risktable_flag = config.get("result").get("risktable", False)
+    survival_flag = config.get("result").get("survival", False)
     efs_flag = args.get('efsFlag', False)
 
     log_obj = {}

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -11,17 +11,19 @@ from PcdcAnalysisTools.errors import AuthError, NotFoundError
 import numpy as np
 import pandas as pd
 
+DEFAULT_SURVIVAL_CONFIG = {"consortium": [], "result": {}}
+
 
 @auth.authorize_for_analysis("access")
 def get_config():
-    config = capp.config.get("SURVIVAL", {"consortium": [], "result": {}})
+    config = capp.config.get("SURVIVAL", DEFAULT_SURVIVAL_CONFIG)
     return flask.jsonify(config)
 
 
 @auth.authorize_for_analysis("access")
 def get_result():
     args = utils.parse.parse_request_json()
-    config = capp.config.get("SURVIVAL", {"consortium": [], "result": {}})
+    config = capp.config.get("SURVIVAL", DEFAULT_SURVIVAL_CONFIG)
 
     # TODO add json payload control
     # TODO add check on payload nulls and stuff

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -90,10 +90,10 @@ def fetch_data(filters, efs_flag):
 
             if MISSING_EVENT_FREE_TIME_VAR and each.get(EVENT_FREE_TIME_VAR) is not None:
                 MISSING_EVENT_FREE_TIME_VAR = False
-            
+
             if not MISSING_EVENT_FREE_STATUS_VAR and not MISSING_EVENT_FREE_TIME_VAR:
                 break
-                
+
         if MISSING_EVENT_FREE_STATUS_VAR or MISSING_EVENT_FREE_TIME_VAR:
             raise NotFoundError("The cohort selected has no {} and/or no {}. The event free curve can't be built without these necessary data points.".format(
                 EVENT_FREE_STATUS_VAR, EVENT_FREE_TIME_VAR))

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -69,15 +69,17 @@ def fetch_data(config, filters, efs_flag):
         else (OVERALL_STATUS_STR, OVERALL_STATUS_VAR, OVERALL_TIME_VAR)
     )
 
-    filters.setdefault("AND", [])
-    filters["AND"].append({"IN": {"consortium": config.get('consortium')}})
-
     guppy_data = utils.guppy.downloadDataFromGuppy(
         path=capp.config['GUPPY_API'] + "/download",
         type="subject",
         totalCount=100000,
         fields=[status_var, time_var],
-        filters=filters,
+        filters={
+            "AND": [
+                {"IN": {"consortium": config.get('consortium')}},
+                filters
+            ]
+        },
         sort=[],
         accessibility="accessible",
         config=capp.config

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -15,7 +15,7 @@ import pandas as pd
 @auth.authorize_for_analysis("access")
 def get_result():
     args = utils.parse.parse_request_json()
-    config = capp.config.get("SURVIVAL", {"result": {}})
+    config = capp.config.get("SURVIVAL", {"consortium": [], "result": {}})
 
     # TODO add json payload control
     # TODO add check on payload nulls and stuff
@@ -44,7 +44,7 @@ def get_result():
     for filter_set in filter_sets:
         # the default "All Subjects" option has filter set id of -1
         filter_set_id = filter_set.get("id")
-        data = fetch_data(filter_set.get("filters"), efs_flag)
+        data = fetch_data(config, filter_set.get("filters"), efs_flag)
         result = get_survival_result(data, risktable_flag, survival_flag)
 
         survival_results[filter_set_id] = result
@@ -62,7 +62,7 @@ OVERALL_STATUS_VAR = "survival_characteristics.lkss"
 OVERALL_TIME_VAR = "survival_characteristics.age_at_lkss"
 
 
-def fetch_data(filters, efs_flag):
+def fetch_data(config, filters, efs_flag):
     status_str, status_var, time_var = (
         (EVENT_FREE_STATUS_STR, EVENT_FREE_STATUS_VAR, EVENT_FREE_TIME_VAR)
         if efs_flag
@@ -70,6 +70,7 @@ def fetch_data(filters, efs_flag):
     )
 
     filters.setdefault("AND", [])
+    filters["AND"].append({"IN": {"consortium": config.get('consortium')}})
 
     guppy_data = utils.guppy.downloadDataFromGuppy(
         path=capp.config['GUPPY_API'] + "/download",

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -13,6 +13,12 @@ import pandas as pd
 
 
 @auth.authorize_for_analysis("access")
+def get_config():
+    config = capp.config.get("SURVIVAL", {"consortium": [], "result": {}})
+    return flask.jsonify(config)
+
+
+@auth.authorize_for_analysis("access")
 def get_result():
     args = utils.parse.parse_request_json()
     config = capp.config.get("SURVIVAL", {"consortium": [], "result": {}})


### PR DESCRIPTION
Ticket: [PEDS-836](https://pcdc.atlassian.net/browse/PEDS-836)

This PR implements the use of server-side survival configuration of the following type:

```python
{
    consortium: list[str],
    result: {
        risktable: bool,
        survival: bool
    }
}
```

The configuration value is accessible at `flask.current_app.config.get("SURVIVAL")`. The default configuration value is `{"consortium": [], "result: {}}`, which corresponds to no analysis result.

`"consortium"` value is used to supply a list of consortium values that support survival analysis for their data and is dynamically added to the `filters` value when querying guppy data.

The PR also adds a new endpoint `/survival/config` to serve the server-side configuration.
