### PR TITLE
PEDS-847

### DIFF
--- a/PcdcAnalysisTools/api.py
+++ b/PcdcAnalysisTools/api.py
@@ -13,7 +13,7 @@ from cdispyutils.uwsgi import setup_user_harakiri
 from gen3authz.client.arborist.client import ArboristClient
 from pcdcutils.environment import is_env_enabled
 from pcdcutils.signature import SignatureManager
-
+from flask import Response, request
 
 import PcdcAnalysisTools
 from PcdcAnalysisTools.errors import (
@@ -150,6 +150,15 @@ def version():
     base = {"version": VERSION, "commit": COMMIT}
 
     return jsonify(base), 200
+
+@app.route("/case_ids", methods=["GET"])
+def download_case_ids():
+    data = request.args['data']
+    return Response(
+        data,
+        mimetype='text/plain',
+        headers={'Content-Disposition': 'attachment; filename=case_ids.txt'}
+    )
 
 
 @app.errorhandler(404)

--- a/PcdcAnalysisTools/blueprint/routes/views/external/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/external/__init__.py
@@ -2,7 +2,6 @@ import json
 import flask
 import urllib.parse
 from flask import current_app as capp
-from flask import request
 
 
 from PcdcAnalysisTools import utils


### PR DESCRIPTION
When using the Explore in An External Data Commons feature, if the URL is too long, instead of redirecting to the Genomic Data Commons website, the application returns a text file with the UUID for the cases, separated by commas.

### New Features
- Added an endpoint (/analysis/case_ids) to return the case UUIDs as a file.

