### PR TITLE
fix EFS curve generation issue

### DIFF
--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -122,8 +122,8 @@ def fetch_data(config, filters, efs_flag):
                         each[age_at_disease_phase] = n.get(age_at_disease_phase)
         if age_at_disease_phase in each:
             del each[node]
-        else:
-            each[age_at_disease_phase] = None
+        # else:
+        #     each[age_at_disease_phase] = None
 
         if efs_flag:
             if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
@@ -208,14 +208,10 @@ def get_survival_result(data, risktable_flag, survival_flag):
 
         return result
 
+    if len(data_kmf) < 2:
+        raise NotFoundError("The systems needs at least 2 data points to draw the curve.")
+
     kmf = KaplanMeierFitter()
-    print("LUCAAAAAA")
-    print(data_kmf)
-    # data_kmf = data_kmf.index.repeat(2)
-    data_kmf = data_kmf.append({'omitted': False, 'status': True, 'time': 1}, ignore_index=True)
-    print(data_kmf)
-
-
     kmf.fit(data_kmf.time, data_kmf.status)
 
     if risktable_flag:

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -122,8 +122,8 @@ def fetch_data(config, filters, efs_flag):
                         each[age_at_disease_phase] = n.get(age_at_disease_phase)
         if age_at_disease_phase in each:
             del each[node]
-        # else:
-        #     each[age_at_disease_phase] = None
+        else:
+            each[age_at_disease_phase] = None
 
         if efs_flag:
             if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
@@ -212,7 +212,7 @@ def get_survival_result(data, risktable_flag, survival_flag):
     print("LUCAAAAAA")
     print(data_kmf)
     # data_kmf = data_kmf.index.repeat(2)
-    data_kmf = data_kmf.append({'omitted': False, 'status': True, 'time': 1})
+    data_kmf = data_kmf.append({'omitted': False, 'status': True, 'time': 1}, ignore_index=True)
     print(data_kmf)
 
 

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -124,7 +124,6 @@ def fetch_data(config, filters, efs_flag):
             del each[node]
 
         if efs_flag:
-            print(each)
             if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
                 MISSING_STATUS_VAR = False
 
@@ -208,6 +207,8 @@ def get_survival_result(data, risktable_flag, survival_flag):
         return result
 
     kmf = KaplanMeierFitter()
+    print("LUCAAAAAA")
+    print(data_kmf)
     kmf.fit(data_kmf.time, data_kmf.status)
 
     if risktable_flag:

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -122,6 +122,7 @@ def fetch_data(config, filters, efs_flag):
                         each[age_at_disease_phase] = n.get(age_at_disease_phase)
 
         if efs_flag:
+            print(each)
             if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
                 MISSING_STATUS_VAR = False
 
@@ -134,9 +135,11 @@ def fetch_data(config, filters, efs_flag):
             print(each)
             survival_dict_tmp = each.get("survival_characteristics")
             survival_dict = None
-            for surv in survival_dict_tmp:
-                if not survival_dict or surv["age_at_lkss"] > survival_dict["age_at_lkss"]:
-                    survival_dict = surv
+
+            if survival_dict_tmp:
+                for surv in survival_dict_tmp:
+                    if not survival_dict or surv["age_at_lkss"] > survival_dict["age_at_lkss"]:
+                        survival_dict = surv
 
             if survival_dict:
                 del each["survival_characteristics"]
@@ -159,7 +162,8 @@ def fetch_data(config, filters, efs_flag):
         .assign(
             omitted=lambda x:
                 ((x[status_var].isna()) | (x[status_var] == 'Unknown') |
-                 (x[time_var].isna()) | (x[time_var] < 0)),
+                 (x[time_var].isna()) | (x[time_var] < 0) |
+                 (x[age_at_disease_phase].isna())),
             status=lambda x:
                 np.where(x["omitted"], None, x[status_var] == status_str),
             time=lambda x:

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -131,9 +131,6 @@ def fetch_data(config, filters, efs_flag):
 
             if MISSING_TIME_VAR and each.get(EVENT_FREE_TIME_VAR) is not None:
                 MISSING_TIME_VAR = False
-
-            if not MISSING_STATUS_VAR and not MISSING_TIME_VAR:
-                break
         elif not efs_flag:
             survival_dict_tmp = each.get("survival_characteristics")
             survival_dict = None

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -33,8 +33,6 @@ def get_result():
     # TODO add check on payload nulls and stuff
     # TODO add path in the config file or ENV variable
     filter_sets = json.loads(json.dumps(args.get("filterSets")))
-    # NOT USED FOR NOW
-    # efs_flag = args.get("efsFlag")
     risktable_flag = config.get("result").get("risktable", False)
     survival_flag = config.get("result").get("survival", False)
     efs_flag = args.get('efsFlag', False)
@@ -74,6 +72,9 @@ OVERALL_STATUS_STR = "Dead"
 OVERALL_STATUS_VAR = "survival_characteristics.lkss"
 OVERALL_TIME_VAR = "survival_characteristics.age_at_lkss"
 
+# TODO are this the correct variables to check or should I use tumor_assessment? or others?
+AGE_AT_DISEASE_PHASE = "survival_characteristics.age_at_disease_phase"
+DISEASE_PHASE = "survival_characteristics.disease_phase"
 
 def fetch_data(config, filters, efs_flag):
     status_str, status_var, time_var = (
@@ -92,7 +93,7 @@ def fetch_data(config, filters, efs_flag):
         path=capp.config['GUPPY_API'] + "/download",
         type="subject",
         totalCount=100000,
-        fields=[status_var, time_var],
+        fields=[status_var, time_var, DISEASE_PHASE, AGE_AT_DISEASE_PHASE],
         filters=(
             {"AND": [
                 {"IN": {"consortium": config.get('consortium')}},
@@ -106,43 +107,49 @@ def fetch_data(config, filters, efs_flag):
         config=capp.config
     )
 
-    if efs_flag:
-        MISSING_EVENT_FREE_STATUS_VAR = True
-        MISSING_EVENT_FREE_TIME_VAR = True
-        for each in guppy_data:
-            if MISSING_EVENT_FREE_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
-                MISSING_EVENT_FREE_STATUS_VAR = False
 
-            if MISSING_EVENT_FREE_TIME_VAR and each.get(EVENT_FREE_TIME_VAR) is not None:
-                MISSING_EVENT_FREE_TIME_VAR = False
+    node, age_at_disease_phase = AGE_AT_DISEASE_PHASE.split('.')
+    node, disease_phase = DISEASE_PHASE.split('.')
 
-            if not MISSING_EVENT_FREE_STATUS_VAR and not MISSING_EVENT_FREE_TIME_VAR:
+    MISSING_STATUS_VAR = True
+    MISSING_TIME_VAR = True
+    for each in guppy_data:
+        # Get the age at initial diagnosis
+        dict_tmp = each.get(node)
+        if dict_tmp:
+            for n in dict_tmp:
+                if n.get(disease_phase) == "Initial Diagnosis":
+                    each[age_at_disease_phase] = n.get(age_at_disease_phase)
+                    break
+
+        if efs_flag:
+            if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
+                MISSING_STATUS_VAR = False
+
+            if MISSING_TIME_VAR and each.get(EVENT_FREE_TIME_VAR) is not None:
+                MISSING_TIME_VAR = False
+
+            if not MISSING_STATUS_VAR and not MISSING_TIME_VAR:
                 break
-
-        if MISSING_EVENT_FREE_STATUS_VAR or MISSING_EVENT_FREE_TIME_VAR:
-            raise NotFoundError("The cohort selected has no {} and/or no {}. The event free curve can't be built without these necessary data points.".format(
-                EVENT_FREE_STATUS_VAR, EVENT_FREE_TIME_VAR))
-    elif not efs_flag:
-        MISSING_OVERALL_STATUS_VAR = True
-        MISSING_OVERALL_TIME_VAR = True
-
-        for each in guppy_data:
+        elif not efs_flag:
             survival_dict_tmp = each.get("survival_characteristics")
             if survival_dict_tmp:
+                # TODO get the one with the older date
                 survival_dict = survival_dict_tmp[0]
                 del each["survival_characteristics"]
 
                 each[status_var] = survival_dict.get("lkss")
                 if each[status_var] is not None:
-                    MISSING_OVERALL_STATUS_VAR = False
+                    MISSING_STATUS_VAR = False
 
                 each[time_var] = survival_dict.get("age_at_lkss")
                 if each[time_var] is not None:
-                    MISSING_OVERALL_TIME_VAR = False
+                    MISSING_TIME_VAR = False
 
-        if MISSING_OVERALL_STATUS_VAR or MISSING_OVERALL_TIME_VAR:
-            raise NotFoundError(
-                "The cohort selected has no {} and/or no {}. The event free curve can't be built without these necessary data points.".format(OVERALL_STATUS_VAR, OVERALL_TIME_VAR))
+    if MISSING_STATUS_VAR or MISSING_TIME_VAR:
+        raise NotFoundError("The cohort selected has no {} and/or no {}. The curve can't be built without these necessary data points.".format(
+            EVENT_FREE_STATUS_VAR if efs_flag else OVERALL_STATUS_VAR, EVENT_FREE_TIME_VAR if efs_flag else OVERALL_TIME_VAR))
+   
 
     return (
         pd.DataFrame.from_records(guppy_data)
@@ -153,7 +160,7 @@ def fetch_data(config, filters, efs_flag):
             status=lambda x:
                 np.where(x["omitted"], None, x[status_var] == status_str),
             time=lambda x:
-                np.where(x["omitted"], None, x[time_var] / 365.25)
+                np.where(x["omitted"], None, (x[time_var] - x[age_at_disease_phase]) / 365.25)        
         )
         .filter(items=["omitted", "status", "time"])
     )

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -120,6 +120,8 @@ def fetch_data(config, filters, efs_flag):
                 if n.get(disease_phase) == "Initial Diagnosis" and n.get(age_at_disease_phase):
                     if age_at_disease_phase not in each or n.get(age_at_disease_phase) < each[age_at_disease_phase]:
                         each[age_at_disease_phase] = n.get(age_at_disease_phase)
+        if each[age_at_disease_phase]:
+            del each[node]
 
         if efs_flag:
             print(each)
@@ -132,7 +134,6 @@ def fetch_data(config, filters, efs_flag):
             if not MISSING_STATUS_VAR and not MISSING_TIME_VAR:
                 break
         elif not efs_flag:
-            print(each)
             survival_dict_tmp = each.get("survival_characteristics")
             survival_dict = None
 

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -122,6 +122,8 @@ def fetch_data(config, filters, efs_flag):
                         each[age_at_disease_phase] = n.get(age_at_disease_phase)
         if age_at_disease_phase in each:
             del each[node]
+        # else:
+        #     each[age_at_disease_phase] = None
 
         if efs_flag:
             if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
@@ -163,11 +165,11 @@ def fetch_data(config, filters, efs_flag):
             omitted=lambda x:
                 ((x[status_var].isna()) | (x[status_var] == 'Unknown') |
                  (x[time_var].isna()) | (x[time_var] < 0) |
-                 (x[age_at_disease_phase].isna())),
+                 (x[age_at_disease_phase].isna()) | (x[age_at_disease_phase] < 0)),
             status=lambda x:
                 np.where(x["omitted"], None, x[status_var] == status_str),
             time=lambda x:
-                np.where(x["omitted"], None, (x[time_var] - x[age_at_disease_phase]) / 365.25)        
+                np.where(x["omitted"], None, float((x[time_var] - x[age_at_disease_phase]) / 365.25))        
         )
         .filter(items=["omitted", "status", "time"])
     )

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -131,6 +131,7 @@ def fetch_data(config, filters, efs_flag):
             if not MISSING_STATUS_VAR and not MISSING_TIME_VAR:
                 break
         elif not efs_flag:
+            print(each)
             survival_dict_tmp = each.get("survival_characteristics")
             survival_dict = None
             for surv in survival_dict_tmp:

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -120,7 +120,7 @@ def fetch_data(config, filters, efs_flag):
                 if n.get(disease_phase) == "Initial Diagnosis" and n.get(age_at_disease_phase):
                     if age_at_disease_phase not in each or n.get(age_at_disease_phase) < each[age_at_disease_phase]:
                         each[age_at_disease_phase] = n.get(age_at_disease_phase)
-        if each[age_at_disease_phase]:
+        if age_at_disease_phase in each:
             del each[node]
 
         if efs_flag:

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -169,7 +169,7 @@ def fetch_data(config, filters, efs_flag):
             status=lambda x:
                 np.where(x["omitted"], None, x[status_var] == status_str),
             time=lambda x:
-                np.where(x["omitted"], None, float((x[time_var] - x[age_at_disease_phase]) / 365.25))        
+                np.where(x["omitted"], None, (x[time_var] - x[age_at_disease_phase]) / 365.25)        
         )
         .filter(items=["omitted", "status", "time"])
     )
@@ -211,6 +211,11 @@ def get_survival_result(data, risktable_flag, survival_flag):
     kmf = KaplanMeierFitter()
     print("LUCAAAAAA")
     print(data_kmf)
+    # data_kmf = data_kmf.index.repeat(2)
+    data_kmf = data_kmf.append({'omitted': False, 'status': True, 'time': 1})
+    print(data_kmf)
+
+
     kmf.fit(data_kmf.time, data_kmf.status)
 
     if risktable_flag:

--- a/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
+++ b/PcdcAnalysisTools/blueprint/routes/views/survival/__init__.py
@@ -72,9 +72,8 @@ OVERALL_STATUS_STR = "Dead"
 OVERALL_STATUS_VAR = "survival_characteristics.lkss"
 OVERALL_TIME_VAR = "survival_characteristics.age_at_lkss"
 
-# TODO are this the correct variables to check or should I use tumor_assessment? or others?
-AGE_AT_DISEASE_PHASE = "survival_characteristics.age_at_disease_phase"
-DISEASE_PHASE = "survival_characteristics.disease_phase"
+AGE_AT_DISEASE_PHASE = "timings.age_at_disease_phase"
+DISEASE_PHASE = "timings.disease_phase"
 
 def fetch_data(config, filters, efs_flag):
     status_str, status_var, time_var = (
@@ -118,9 +117,9 @@ def fetch_data(config, filters, efs_flag):
         dict_tmp = each.get(node)
         if dict_tmp:
             for n in dict_tmp:
-                if n.get(disease_phase) == "Initial Diagnosis":
-                    each[age_at_disease_phase] = n.get(age_at_disease_phase)
-                    break
+                if n.get(disease_phase) == "Initial Diagnosis" and n.get(age_at_disease_phase):
+                    if age_at_disease_phase not in each or n.get(age_at_disease_phase) < each[age_at_disease_phase]:
+                        each[age_at_disease_phase] = n.get(age_at_disease_phase)
 
         if efs_flag:
             if MISSING_STATUS_VAR and each.get(EVENT_FREE_STATUS_VAR) is not None:
@@ -133,9 +132,12 @@ def fetch_data(config, filters, efs_flag):
                 break
         elif not efs_flag:
             survival_dict_tmp = each.get("survival_characteristics")
-            if survival_dict_tmp:
-                # TODO get the one with the older date
-                survival_dict = survival_dict_tmp[0]
+            survival_dict = None
+            for surv in survival_dict_tmp:
+                if not survival_dict or surv["age_at_lkss"] > survival_dict["age_at_lkss"]:
+                    survival_dict = surv
+
+            if survival_dict:
                 del each["survival_characteristics"]
 
                 each[status_var] = survival_dict.get("lkss")


### PR DESCRIPTION
If Event Free Survival was selected there was an extra break that was terminating the loop too early and the resulting data had no timing information associated