### PR TITLE
Update poetry.lock to version 5.0 for pcdcutils #16

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3007,7 +3007,7 @@ setuptools = "*"
 
 [[package]]
 name = "pcdcutils"
-version = "0.4.1"
+version = "0.5.0"
 description = "PCDC Utilities for Python"
 optional = false
 python-versions = ">=3.9,<4.0"
@@ -3024,7 +3024,7 @@ pycryptodome = "3.21.0"
 type = "git"
 url = "https://github.com/chicagopcdc/pcdcutils.git"
 reference = "0.5.0"
-resolved_reference = "5e171252f396c1ad2b87624d0ebcb37a53abc5e4"
+resolved_reference = "5aebea8bb20996a8a0043c55b7575f0912f011e1"
 
 [[package]]
 name = "pillow"


### PR DESCRIPTION
Parent: https://github.com/chicagopcdc/PcdcAnalysisTools/pull/100
Jira: https://pcdc.atlassian.net/browse/PEDS-1379
Improvements: Update poetry.lock for the new version of pcdcutils.